### PR TITLE
S/weekly summary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ run-development: ${RUN_DEVELOPMENT_FILE} ${ENV_FILE} ${GITHUB_EVENT_PATH} ## Run
 	env $(ENVIRONMENT) \
 		INPUT_GITHUB_TOKEN=${GITHUB_PACKAGE_PULL_TOKEN} \
 		GITHUB_EVENT_PATH=${GITHUB_EVENT_PATH} \
-		node ./tmp/run-development.js
+		node --inspect ./tmp/run-development.js
 
 help: ## Runs the help!
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ clean: ## remove built files
 
 .PHONY: lint
 lint: ## check for formatting errors
-	eslint --quiet src/**/*.ts
+	eslint --quiet src/**/**/*.ts
 
 .PHONY: test
 test: ## verify functionality

--- a/__tests__/summary_report.test.ts
+++ b/__tests__/summary_report.test.ts
@@ -1,6 +1,6 @@
 import { mocked } from 'ts-jest/utils';
 import { summaryReport } from '../src/summary_report';
-import { getClosedInPastWeek, getDetailedPR } from '../src/github';
+import { getClosedInPastWeek, getDetailedPR, getDetailedIssue } from '../src/github';
 import { postMessage } from '../src/slack';
 
 jest.mock('../src/input');
@@ -8,27 +8,82 @@ jest.mock('../src/github');
 jest.mock('../src/slack');
 
 describe('::summaryReport', () => {
-  it('sends a csv to slack', async () => {
-    let pullRequest;
-    pullRequest = {
-      number: 1,
-    };
+  describe('slack csv', () => {
+    describe('pr', () => {
+      const htmlURL = 'https://github.com/my-org/my-project/pull/26386';
+      const commitSHA = 'eee9b64';
 
-    let detailedPullRequest;
-    detailedPullRequest = {
-      html_url: "www.url.com",
-      title: "hi",
-      user: {login: "name"},
-      merged: 'a date',
-      merged_by: {login: "name"},
-      labels: ['label one', 'label two'],
-    };
-    mocked(getClosedInPastWeek).mockResolvedValue([pullRequest]);
-    mocked(getDetailedPR).mockResolvedValue(detailedPullRequest);
-    await summaryReport();
-    expect(postMessage).toHaveBeenCalledWith(expect.stringMatching(/url,title,creator,merged,merged_by,closed_at,labels,review_comments/i));
-    expect(postMessage).toHaveBeenCalledWith(
-      expect.stringMatching("www.url.com\",\"hi\",\"name\",\"a date\",\"name\",undefined,label one,label two,undefined")
-    );
+      function mockPR(overrides = {} as any) {
+        const pullRequest = {
+          number: 1,
+          pull_request: {
+          },
+        };
+
+        const detailedPullRequest = {
+          html_url: htmlURL,
+          labels: [],
+          merge_commit_sha: commitSHA,
+          user: {},
+          ...overrides,
+        } as any;
+
+        mocked(getClosedInPastWeek).mockResolvedValue([pullRequest]);
+        mocked(getDetailedPR).mockResolvedValue(detailedPullRequest);
+      };
+
+      describe('merged', () => {
+        beforeEach(() => {
+          mockPR({
+            merged: true,
+          });
+        });
+
+        it('is included', async () => {
+          await summaryReport();
+
+          expect(postMessage).toHaveBeenCalledWith(expect.stringMatching(htmlURL));
+          expect(postMessage).toHaveBeenCalledWith(expect.stringMatching(commitSHA));
+          expect(postMessage).toHaveBeenCalledWith(expect.stringMatching('code-change'));
+        });
+      });
+
+      describe('closed but not merged', () => {
+        beforeEach(() => {
+          mockPR({
+            merged: false,
+          });
+        });
+
+
+        it('is not included', async () => {
+          await summaryReport();
+          expect(postMessage).not.toHaveBeenCalledWith(expect.stringMatching(htmlURL));
+        });
+      });
+    });
+
+    it('includes issues (access requests)', async () => {
+      const issue = {
+        number: 2,
+        pull_request: undefined,
+      };
+
+      const htmlURL = 'https://github.com/my-org/my-project/issue/26386';
+      const detailedIssue = {
+        html_url: htmlURL,
+        labels: [],
+        merge_commit_sha: undefined,
+        user: {},
+      } as any;
+
+      mocked(getClosedInPastWeek).mockResolvedValue([issue]);
+      mocked(getDetailedIssue).mockResolvedValue(detailedIssue);
+
+      await summaryReport();
+
+      expect(postMessage).toHaveBeenCalledWith(expect.stringMatching(htmlURL));
+      expect(postMessage).toHaveBeenCalledWith(expect.stringMatching('access-request'));
+    });
   });
 });

--- a/src/__mocks__/github.ts
+++ b/src/__mocks__/github.ts
@@ -4,4 +4,5 @@ export const tagCIChecksOnPR = jest.fn();
 export const getStatusOfMaster = jest.fn();
 export const getMergedEmergencyPRsMissingReview  = jest.fn();
 export const getDetailedPR  = jest.fn();
+export const getDetailedIssue = jest.fn();
 export const getClosedInPastWeek  = jest.fn();

--- a/src/github.ts
+++ b/src/github.ts
@@ -46,14 +46,14 @@ export async function getMergedEmergencyPRsMissingReview() {
 }
 
 export async function getClosedInPastWeek() {
-  let date = new Date()
-  date.setDate(date.getDate() - 7)
-  let closedDate = date.toISOString().substr(0, 10)
+  const date = new Date();
+  date.setDate(date.getDate() - 7);
+  const closedDate = date.toISOString().substr(0, 10);
   const { data } = await client.search.issuesAndPullRequests({
     q: [
       `repo:${REPO_SLUG}`,
       `state:${CLOSED}`,
-      `closed:>${closedDate}`
+      `closed:>${closedDate}`,
     ].join('+'),
   });
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -15,6 +15,7 @@ const { owner, repo } = context.repo;
 
 const CLOSED = 'closed';
 const MASTER = 'master';
+const SEARCH_PER_PAGE = 30;
 
 export const client = new github.GitHub(githubToken);
 export const REPO_SLUG = `${owner}/${repo}`;
@@ -48,16 +49,31 @@ export async function getMergedEmergencyPRsMissingReview() {
 export async function getClosedInPastWeek() {
   const date = new Date();
   date.setDate(date.getDate() - 7);
-  const closedDate = date.toISOString().substr(0, 10);
-  const { data } = await client.search.issuesAndPullRequests({
+  const since = date.toISOString().substr(0, 10);
+  return getClosedIssues(since);
+}
+
+async function getClosedIssues(since, previousIssues = [], page = 1) {
+  const { data: { items, total_count } } = await client.search.issuesAndPullRequests({
+    page,
     q: [
       `repo:${REPO_SLUG}`,
       `state:${CLOSED}`,
-      `closed:>${closedDate}`,
+      `closed:>${since}`,
     ].join('+'),
   });
 
-  return data.items.filter(i => i.pull_request);
+  const issues = [...previousIssues, ...items];
+  return (total_count > page * SEARCH_PER_PAGE) ? getClosedIssues(since, issues, page + 1) : issues;
+}
+
+export async function getDetailedIssue(number) {
+  const { data } = await client.issues.get({
+    owner,
+    repo,
+    issue_number: number,
+  });
+  return data;
 }
 
 export async function getDetailedPR(number) {

--- a/src/summary_report.ts
+++ b/src/summary_report.ts
@@ -1,6 +1,5 @@
-import * as core from '@actions/core';
 import { getClosedInPastWeek, getDetailedPR } from './github';
-import { ExportToCsv  } from 'export-to-csv';
+import { ExportToCsv } from 'export-to-csv';
 import { postMessage } from './slack';
 
 export async function summaryReport() {
@@ -12,12 +11,11 @@ export async function summaryReport() {
     useTextFile: false,
     useBom: true,
     useKeysAsHeaders: true,
-  }
-
-  const csvExporter = new ExportToCsv(options);
-  let data = []
+  };
 
   try {
+    const csvExporter = new ExportToCsv(options);
+    const data = [];
     const pullRequests = await getClosedInPastWeek();
 
     for(const pr of pullRequests) {
@@ -25,12 +23,14 @@ export async function summaryReport() {
       const row = createRow(detailed_pr);
       data.push(row);
     }
+
+    // For why we pass in true:
+    // https://github.com/alexcaza/export-to-csv/issues/2
+    await postMessage(csvExporter.generateCsv(data, true));
   } catch (error) {
-    let data = "Summary report creation failed! 🔥"
+    await postMessage("Summary report creation failed! 🔥");
+    throw error;
   }
-  // For why we pass in true:
-  // https://github.com/alexcaza/export-to-csv/issues/2
-  await postMessage(csvExporter.generateCsv(data, true));
 }
 
 function createRow(pr) {

--- a/src/summary_report.ts
+++ b/src/summary_report.ts
@@ -1,47 +1,95 @@
-import { getClosedInPastWeek, getDetailedPR } from './github';
 import { ExportToCsv } from 'export-to-csv';
 import { postMessage } from './slack';
 
+import {
+  getClosedInPastWeek,
+  getDetailedPR,
+  getDetailedIssue,
+  REPO_SLUG,
+} from './github';
+
+const ACCESS_REQUEST = 'access-request';
+const BLANK = '';
+const NEWLINE = '\n';
+const CODE_CHANGES = 'code-change';
+const FAILED = 'Summary report creation failed! 🔥';
+const SEPARATOR = ',';
+const WEEKLY_REPORT = ':rolled_up_newspaper: Weekly Report';
+
+const OPTIONS = {
+  fieldSeparator: ',',
+  quoteStrings: '"',
+  decimalSeparator: '.',
+  showLabels: true,
+  useTextFile: false,
+  useBom: true,
+  useKeysAsHeaders: true,
+};
+
+const csvExporter = new ExportToCsv(OPTIONS);
+
+// all pull requests are issues, but not all issues are pull requests
+function isPullRequest(prOrIssue) {
+  return !!prOrIssue.pull_request;
+}
+
 export async function summaryReport() {
-  const options = {
-    fieldSeparator: ',',
-    quoteStrings: '"',
-    decimalSeparator: '.',
-    showLabels: true,
-    useTextFile: false,
-    useBom: true,
-    useKeysAsHeaders: true,
-  };
-
   try {
-    const csvExporter = new ExportToCsv(options);
-    const data = [];
-    const pullRequests = await getClosedInPastWeek();
+    const rows = [];
+    let issueCount = 0;
+    let prCount = 0;
 
-    for(const pr of pullRequests) {
-      const detailed_pr = await getDetailedPR(pr.number);
-      const row = createRow(detailed_pr);
-      data.push(row);
+    const data = await getClosedInPastWeek();
+    for (const issue of data) {
+      let row;
+
+      if (isPullRequest(issue)) {
+        const pullRequest = await getDetailedPR(issue.number);
+        if (!pullRequest.merged) continue;
+        row = createRow(true, pullRequest);
+        prCount++;
+      } else {
+        const detailedIssue = await getDetailedIssue(issue.number);
+        row = createRow(false, detailedIssue);
+        issueCount++;
+      }
+
+      rows.push(row);
+    };
+
+    await postMessage(`${WEEKLY_REPORT} ${prCount} ${CODE_CHANGES}s, ${issueCount} ${ACCESS_REQUEST}s`);
+
+    if (rows.length) {
+      const csv = csvExporter.generateCsv(rows, true);
+      const report = csv.split(NEWLINE).map(line => `> ${line}`).join(NEWLINE);
+      await postMessage(report);
     }
-
-    // For why we pass in true:
-    // https://github.com/alexcaza/export-to-csv/issues/2
-    await postMessage(csvExporter.generateCsv(data, true));
   } catch (error) {
-    await postMessage("Summary report creation failed! 🔥");
+    await postMessage(FAILED);
     throw error;
   }
 }
 
-function createRow(pr) {
-  return {
-    url: pr.html_url,
-    title: pr.title,
-    creator: pr.user.login,
-    merged: pr.merged,
-    merged_by: pr.merged_by.login,
-    closed_at: pr.closed_at,
-    labels: pr.labels,
-    review_comments: pr.review_comments,
-  };
+function createRow(isPR, issue) {
+  const issueDetail = `<${issue.html_url}|${issue.number}>`;
+
+  return removeUndefines({
+    type: (isPR) ? CODE_CHANGES : ACCESS_REQUEST,
+    project: REPO_SLUG,
+    issue: issueDetail,
+    merge_commit_sha: issue.merge_commit_sha,
+    merged_by: issue.merged_by?.login,
+    closed_at: issue.closed_at,
+    labels: issue.labels.map(l => l.name).join(SEPARATOR),
+    review_comments: issue.review_comments,
+    creator: issue.user.login,
+    title: issue.title,
+  });
+}
+
+function removeUndefines(rows) {
+  for (const key in rows) {
+    if (typeof rows[key] === 'undefined') rows[key] = BLANK;
+  }
+  return rows;
 }


### PR DESCRIPTION
This addresses a few problems with the weekly report

* Fails the action (with details) if it fails
* Recursively pulls closed issues rather than stopping at the first 30
* Includes issues (access requests) in report
* Filters unmerged, but closed, prs


It also fixes the lint matcher and existing lint errors.