### PR TITLE
action.yml has inputs, not input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: 'breakglass'
 description: 'bypass safeguards in an emergency'
 author: 'Reverb LLC'
-input:
+inputs:
   slack_hook:
     description: Slack webhook for announcements
     required: true


### PR DESCRIPTION
This cleans up noise about workflows using unsupported inputs.

https://help.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputs